### PR TITLE
Only ask for browser notifications if they are supported

### DIFF
--- a/client/lib/notifications/browser.js
+++ b/client/lib/notifications/browser.js
@@ -5,7 +5,9 @@ const Notify = notify.default
 
 class BrowserNotifications {
   static requestPermission(cb?: Function) {
-    Notify.requestPermission(cb)
+    if (Notify.isSupported()) {
+      Notify.requestPermission(cb)
+    }
   }
 
   static showNotification(title: string, body: string, notifyClick?: Function, notifyClose?: void) {


### PR DESCRIPTION
Turns out web3 was being detected for Status.im, we were just asking for browser notifications in a browser that does not support them.

I've added a small check to see if browser notifications are supported.

Closes aragon/issues#44 and status-im/status-react#1184